### PR TITLE
Add packaging in type to Maven dependency template

### DIFF
--- a/src/app/artifact/artifact.component.html
+++ b/src/app/artifact/artifact.component.html
@@ -77,7 +77,7 @@
                                   subText="maven.apache.org"
                                   subTextUrl="https://maven.apache.org"
                                   image="mvn"
-                                  value="{{apacheMavenTemplate(group, artifact, version, classifier)}}">
+                                  value="{{apacheMavenTemplate(group, artifact, version, packaging)}}">
       </app-dependency-information>
 
       <app-dependency-information headerText="artifact.gradle"

--- a/src/app/artifact/artifact.component.html
+++ b/src/app/artifact/artifact.component.html
@@ -77,7 +77,7 @@
                                   subText="maven.apache.org"
                                   subTextUrl="https://maven.apache.org"
                                   image="mvn"
-                                  value="{{apacheMavenTemplate(group, artifact, version)}}">
+                                  value="{{apacheMavenTemplate(group, artifact, version, classifier)}}">
       </app-dependency-information>
 
       <app-dependency-information headerText="artifact.gradle"

--- a/src/app/artifact/artifact.component.ts
+++ b/src/app/artifact/artifact.component.ts
@@ -66,8 +66,8 @@ export class ArtifactComponent implements OnInit {
     return `[![Maven Central](https://img.shields.io/maven-central/v/${g}/${a}.svg?label=Maven%20Central)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22${g}%22%20a%3A%22${a}%22)`
   }
 
-  apacheMavenTemplate(g: string, a: string, v: string, c: string): string {
-    return `<dependency>\n  <groupId>${g}</groupId>\n  <artifactId>${a}</artifactId>\n  <version>${v}</version>\n  <type>${c}</type>\n</dependency>`;
+  apacheMavenTemplate(g: string, a: string, v: string, p: string): string {
+    return `<dependency>\n  <groupId>${g}</groupId>\n  <artifactId>${a}</artifactId>\n  <version>${v}</version>\n  <type>${p}</type>\n</dependency>`;
   }
 
   apacheBuildrTemplate(g: string, a: string, v: string): string {

--- a/src/app/artifact/artifact.component.ts
+++ b/src/app/artifact/artifact.component.ts
@@ -67,7 +67,12 @@ export class ArtifactComponent implements OnInit {
   }
 
   apacheMavenTemplate(g: string, a: string, v: string, p: string): string {
-    return `<dependency>\n  <groupId>${g}</groupId>\n  <artifactId>${a}</artifactId>\n  <version>${v}</version>\n  <type>${p}</type>\n</dependency>`;
+    if (p == 'jar') {
+      return `<dependency>\n  <groupId>${g}</groupId>\n  <artifactId>${a}</artifactId>\n  <version>${v}</version>\n</dependency>`;
+    }
+    else {
+      return `<dependency>\n  <groupId>${g}</groupId>\n  <artifactId>${a}</artifactId>\n  <version>${v}</version>\n  <type>${p}</type>\n</dependency>`;
+    }
   }
 
   apacheBuildrTemplate(g: string, a: string, v: string): string {

--- a/src/app/artifact/artifact.component.ts
+++ b/src/app/artifact/artifact.component.ts
@@ -66,8 +66,8 @@ export class ArtifactComponent implements OnInit {
     return `[![Maven Central](https://img.shields.io/maven-central/v/${g}/${a}.svg?label=Maven%20Central)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22${g}%22%20a%3A%22${a}%22)`
   }
 
-  apacheMavenTemplate(g: string, a: string, v: string): string {
-    return `<dependency>\n  <groupId>${g}</groupId>\n  <artifactId>${a}</artifactId>\n  <version>${v}</version>\n</dependency>`;
+  apacheMavenTemplate(g: string, a: string, v: string, c: string): string {
+    return `<dependency>\n  <groupId>${g}</groupId>\n  <artifactId>${a}</artifactId>\n  <version>${v}</version>\n  <type>${c}</type>\n</dependency>`;
   }
 
   apacheBuildrTemplate(g: string, a: string, v: string): string {

--- a/src/app/artifact/artifact.component.ts
+++ b/src/app/artifact/artifact.component.ts
@@ -31,7 +31,7 @@ export class ArtifactComponent implements OnInit {
   group: string;
   artifact: string;
   version: string;
-  classifier: string;
+  packaging: string;
   pom: string;
   searchDocs: SearchDoc[];
   downloadLinks: { name: string, link: string }[];
@@ -47,7 +47,7 @@ export class ArtifactComponent implements OnInit {
       this.group = params['group'];
       this.artifact = params['artifact'];
       this.version = params['version'];
-      this.classifier = params['classifier'];
+      this.packaging = params['packaging'];
 
       this.artifactService.remoteContent(this.remoteRepositoryLink()).subscribe(content => {
         this.pom = content;


### PR DESCRIPTION
This adds a `<type>{packaging}</type>` section to the Maven dependency copy pasta section. 

This pull request makes the following changes:
* Small changes to `src/app/artifact/artifact.component.html` to output the new packaging info
* Small change to `src/app/artifact/artifact.component.ts` to send the packaging to the helper
* Some refactoring to change references to how this is passed so it's more clear what is going where

It relates to the following issue #s:
* Fixes #19 
