### PR TITLE
Fix Leiningen artifact template

### DIFF
--- a/src/app/artifact/artifact.component.ts
+++ b/src/app/artifact/artifact.component.ts
@@ -92,7 +92,7 @@ export class ArtifactComponent implements OnInit {
   }
 
   leiningenTemplate(g: string, a: string, v: string): string {
-    return `[${g}}/${a} "${v}"]`;
+    return `[${g}/${a} "${v}"]`;
   }
 
   gradleGrailsTemplate(g: string, a: string, v: string): string {


### PR DESCRIPTION
The artifact template for Leiningen has an extra `}` that creates incorrect dependency information.

This pull request makes the following changes:
* Removes the extra `}` from the Leiningen artifact template string

-------

Before screenshot:

<img width="1440" alt="screen shot 2018-08-09 at 3 23 20 pm" src="https://user-images.githubusercontent.com/3742606/43924073-375cd270-9be9-11e8-974b-8deefe7f6ca7.png">


After screenshot:

<img width="1440" alt="screen shot 2018-08-09 at 3 27 36 pm" src="https://user-images.githubusercontent.com/3742606/43924072-3748e42c-9be9-11e8-97f5-3fedaa13369c.png">