### PR TITLE
Fix Maven Central Badge link url format

### DIFF
--- a/src/app/artifact/artifact.component.ts
+++ b/src/app/artifact/artifact.component.ts
@@ -92,7 +92,7 @@ export class ArtifactComponent implements OnInit {
   }
 
   mavenCentralBadge(g: string, a: string, v: string): string {
-    return `[![Maven Central](https://img.shields.io/maven-central/v/${g}/${a}.svg?label=Maven%20Central)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22${g}%22%20a%3A%22${a}%22)`
+    return `[![Maven Central](https://img.shields.io/maven-central/v/${g}/${a}.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22${g}%22%20AND%20a:%22${a}%22)`
   }
 
   apacheMavenTemplate(g: string, a: string, v: string, p: string): string {


### PR DESCRIPTION
With the new version of search.maven.org, the search link format is changed. And we need to update the link format used in Maven Central Badge.

This pull request makes the following changes:
* mavenCentralBadge(g,a,v) @ src/app/artifact/artifact.component.ts

(If there are changes to the UI, please include a screenshot so we
know what to look for!) no

(If there are changes to user behavior in general, please make sure to
update the docs, as well) no

It relates to the following issue #s:
* Fixes #45
