### PR TITLE
Short syntax of dependency declaration for Kotlin DSL

### DIFF
--- a/src/app/artifact/dependency-information/dependency-information.component.spec.ts
+++ b/src/app/artifact/dependency-information/dependency-information.component.spec.ts
@@ -85,4 +85,16 @@ describe('DependencyInformationComponent', () => {
     let result = component.provideTemplateOnValue("sbt");
     expect(result).toBe(expected);
   });
+
+  it('should create a valid Gradle Groovy template', () => {
+    let expected = `compile '${g}:${a}:${v}'`;
+    let result = component.provideTemplateOnValue("gradle");
+    expect(result).toBe(expected);
+  });
+
+  it('should create a valid Gradle Kotlin DSL template', () => {
+    let expected = `compile("${g}:${a}:${v}")`;
+    let result = component.provideTemplateOnValue("kotlin");
+    expect(result).toBe(expected);
+  });
 });

--- a/src/app/artifact/dependency-information/dependency-information.component.ts
+++ b/src/app/artifact/dependency-information/dependency-information.component.ts
@@ -136,7 +136,7 @@ export class DependencyInformationComponent implements OnInit {
   }
 
   gradleKotlinDslTemplate(g: string, a: string, v: string): string {
-    return `compile(group = "${g}", name = "${a}", version = "${v}")`;
+    return `compile("${g}:${a}:${v}")`;
   }
 
   purlTemplate(g: string, a: string, v: string): string {


### PR DESCRIPTION
use the same syntax for dependency declaration for Gradle Kotlin DSL as for Groovy DSL