### PR TITLE
Fix #54

### DIFF
--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -123,6 +123,7 @@ export class SearchComponent implements OnInit, OnDestroy {
       // do cleaning
       query = query.trim();
       query = query.replace(/ and /gi, w => w.toUpperCase());
+      query = query.replace(/&&/gi, 'AND');
 
       // Is it a manual search by identifier of Group, Artifact, Version, Packaging, Classifier, Class name or SHA-1
       if (query.length >= 2 && query.charAt(0).match(/[gavplc1]/i) && query.charAt(1) == ':') {


### PR DESCRIPTION
Fix #54

(brief, plain english overview of your changes here)

This pull request makes the following changes:
* replace `&&` in search query to `AND`


(If there are changes to the UI, please include a screenshot so we
know what to look for!) No

(If there are changes to user behavior in general, please make sure to
update the docs, as well) Yes, make `&&` as an alias of `AND` in search query

It relates to the following issue #s:
* Fixes #54 
