### PR TITLE
bug: change target for download links from text to full menu item

### DIFF
--- a/src/app/artifact/artifact.component.html
+++ b/src/app/artifact/artifact.component.html
@@ -118,9 +118,10 @@
         <mat-icon>file_download</mat-icon>
       </button>
       <mat-menu #menuDownloads="matMenu">
-        <button mat-menu-item *ngFor="let dl of downloadLinks">
-          <a target="_blank" href="{{ dl.link }}">{{ dl.name }}</a>
-        </button>
+          <a *ngFor="let dl of downloadLinks"
+             mat-menu-item 
+             target="_blank" 
+             href="{{ dl.link }}" >{{ dl.name }}</a>
       </mat-menu>
     </div>
 


### PR DESCRIPTION
Removes the button from the menu list to make the anchor target span across the whole list item. 
Demo of using anchors for `mat-menu-item` directive: https://stackblitz.com/edit/angular-samuxk?file=app/menu-overview-example.html
