### PR TITLE
Fixes Tooltip for searchAllArtifacts

### DIFF
--- a/src/app/artifacts/artifacts.component.html
+++ b/src/app/artifacts/artifacts.component.html
@@ -68,7 +68,7 @@
               <span class="title" fxHide.gt-xs>A: </span>
               <a [routerLink]="['/search']" [queryParams]="{q: 'a:' + row.a}"
                  (click)="$event.stopPropagation()"
-                 matTooltip="{{ 'artifacts.allArtifacts' | translate }}">{{ row.a }}</a>
+                 matTooltip="{{ 'artifacts.searchAllArtifacts' | translate }}">{{ row.a }}</a>
             </div>
           </td>
         </ng-container>


### PR DESCRIPTION
Fixes Tooltip for searchAllArtifacts

This pull request makes the following changes:
* Make the translate entry correct `artifacts.searchAllArtifacts` vs. `artifacts.allArtifacts`.

(If there are changes to the UI, please include a screenshot so we
know what to look for!) Show tooltip of `Search all artifacts with...` instead of `artifacts.allArtifacts`


(If there are changes to user behavior in general, please make sure to
update the docs, as well) None

It relates to the following issue #s:
* Fixes #X
