### PR TITLE
dev server: proxy requests to search.maven.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,13 @@ We currently follow the [Angular.io style guide](https://angular.io/guide/styleg
 
 #### Data
 
-Using this externally, you'll need to wire up to `http://search.maven.org/solrsearch/select` similar to how we do in Production. You can see these settings in [`environment.prod.ts`](https://github.com/sonatype-nexus-community/search-maven-org/blob/master/src/environments/environment.prod.ts).
+The development server automatically proxies requests to https://search.maven.org/.
 
-You'll likely need to use a plugin to modify CORS headers as this will produce a cross domain request, there are quite a few plugins out there. For Chrome you can use [this one](https://chrome.google.com/webstore/detail/allow-control-allow-origi/nlfbmbojpeacfghkpbjhddihlkkiljbi).
+~~Using this externally, you'll need to wire up to `http://search.maven.org/solrsearch/select` similar to how we do in Production. You can see these settings in [`environment.prod.ts`](https://github.com/sonatype-nexus-community/search-maven-org/blob/master/src/environments/environment.prod.ts).~~
 
-Alternatively, you can use a reverse proxy server like [cors-anywhere](https://github.com/Rob--W/cors-anywhere) to add CORS header to your respose. This would be slow but remove any client side plugin dependency. You can refer following sample config [`environment.prod.ts`](https://github.com/MavenHub/mavenhub-search/blob/master/src/environments/environment.prod.ts).
+~~You'll likely need to use a plugin to modify CORS headers as this will produce a cross domain request, there are quite a few plugins out there. For Chrome you can use [this one](https://chrome.google.com/webstore/detail/allow-control-allow-origi/nlfbmbojpeacfghkpbjhddihlkkiljbi).~~
+
+~~Alternatively, you can use a reverse proxy server like [cors-anywhere](https://github.com/Rob--W/cors-anywhere) to add CORS header to your respose. This would be slow but remove any client side plugin dependency. You can refer following sample config [`environment.prod.ts`](https://github.com/MavenHub/mavenhub-search/blob/master/src/environments/environment.prod.ts).~~
 
 ## Getting help
 

--- a/angular.json
+++ b/angular.json
@@ -50,7 +50,8 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "search-maven-org:build"
+            "browserTarget": "search-maven-org:build",
+            "proxyConfig": "proxy.conf.json"
           },
           "configurations": {
             "production": {

--- a/src/assets/data/appConfig.json
+++ b/src/assets/data/appConfig.json
@@ -1,9 +1,9 @@
 {
     "search": {
-      "endpoint" : "http://localhost:8080/central/solrsearch/select"
+      "endpoint" : "/central/solrsearch/select"
     },
     "stats": {
-      "endpoint" : "http://localhost:8080/central/quickstats"
+      "endpoint" : "/central/quickstats"
     },
     "ossindex": {
       "maven": {
@@ -13,7 +13,7 @@
         "endpoint": "https://ossindex.sonatype.org/resource/package"
       }
     },
-    "smoBaseUrl": "http://localhost:8080/central/remotecontent?filepath=",
+    "smoBaseUrl": "/central/remotecontent?filepath=",
     "repositoryBaseUrl": "https://repo1.maven.org/maven2",
     "smoClassicLookUrl": "https://search.maven.org/classic"
 }


### PR DESCRIPTION
This allows people to start hacking directly without having to think how to setup/proxy/access a live server instance.