### PR TITLE
Use `implementation` for Gradle dependencies

### DIFF
--- a/src/app/artifact/dependency-information/dependency-information.component.ts
+++ b/src/app/artifact/dependency-information/dependency-information.component.ts
@@ -132,11 +132,11 @@ export class DependencyInformationComponent implements OnInit {
   }
 
   gradleGrailsTemplate(g: string, a: string, v: string): string {
-    return `compile '${g}:${a}:${v}'`;
+    return `implementation '${g}:${a}:${v}'`;
   }
 
   gradleKotlinDslTemplate(g: string, a: string, v: string): string {
-    return `compile(group = "${g}", name = "${a}", version = "${v}")`;
+    return `implementation("${g}:${a}:${v}")`;
   }
 
   purlTemplate(g: string, a: string, v: string): string {


### PR DESCRIPTION
While the `compile` configuration is not yet officially deprecated in
vanilla Gradle, its use is discouraged. The Gradle Android Plugin has
even gone a step further and announced it will no longer be supported
in a future release. Thus, `implementation` (which was introduced in
February 2017 with Gradle 3.4) is now used instead of `compile`.