### PR TITLE
Use `implementation` configuration instead of `compile` for Kotlin DSL

### DIFF
--- a/src/app/artifact/dependency-information/dependency-information.component.spec.ts
+++ b/src/app/artifact/dependency-information/dependency-information.component.spec.ts
@@ -93,7 +93,7 @@ describe('DependencyInformationComponent', () => {
   });
 
   it('should create a valid Gradle Kotlin DSL template', () => {
-    let expected = `compile("${g}:${a}:${v}")`;
+    let expected = `implementation("${g}:${a}:${v}")`;
     let result = component.provideTemplateOnValue("kotlin");
     expect(result).toBe(expected);
   });

--- a/src/app/artifact/dependency-information/dependency-information.component.ts
+++ b/src/app/artifact/dependency-information/dependency-information.component.ts
@@ -149,7 +149,7 @@ export class DependencyInformationComponent implements OnChanges {
   }
 
   gradleKotlinDslTemplate(g: string, a: string, v: string): string {
-    return `compile("${g}:${a}:${v}")`;
+    return `implementation("${g}:${a}:${v}")`;
   }
 
   purlTemplate(g: string, a: string, v: string): string {


### PR DESCRIPTION
Replace old `compile` configuration with new `implementation` for Gradle Kotlin DSL

* Fixes #72
