### PR TITLE
UI: Add title to version links to make them more readable when long

### DIFF
--- a/src/app/artifacts/artifacts.component.html
+++ b/src/app/artifacts/artifacts.component.html
@@ -82,6 +82,7 @@
                 <div class="latest">
                   <a
                     [routerLink]="['/artifact', row.g, row.a, (row.v && !row.latestVersion ? row.v :row.latestVersion), row.p]"
+                    title="&lrm; {{ (row.v && !row.latestVersion ? row.v :row.latestVersion) }}"
                     (click)="$event.stopPropagation()">&lrm;
                     {{ (row.v && !row.latestVersion ? row.v :row.latestVersion) }}
                   </a>


### PR DESCRIPTION
When versions are long, they can be truncated on search.maven.org, leading to confusion. You have to go into each of the links in turn to work out what they are, or use the browser's link expansion (usually bottom-left) to see what each URL is. This could be improved by adding a title to the anchors for versions.

This pull request makes the following changes:
* adds a `title` attribute to versions in tables

Before:

<img width="453" alt="Screenshot 2019-07-01 at 23 07 21" src="https://user-images.githubusercontent.com/1038350/60469570-12054800-9c55-11e9-832b-e0e50a24aaf3.png">

After:

<img width="453" alt="Screenshot 2019-07-01 at 23 05 55" src="https://user-images.githubusercontent.com/1038350/60469522-e2eed680-9c54-11e9-948d-cbd0bf4b22ec.png">