### PR TITLE
Update URL to Gradle Kotlin DSL

### DIFF
--- a/src/app/artifact/artifact.component.html
+++ b/src/app/artifact/artifact.component.html
@@ -173,8 +173,8 @@
       </app-dependency-information>
 
       <app-dependency-information i18n-headerText headerText="Gradle Kotlin DSL"
-                                  subText="github.com/gradle/kotlin-dsl"
-                                  subTextUrl="https://github.com/gradle/kotlin-dsl"
+                                  subText="gradle.org/kotlin"
+                                  subTextUrl="https://gradle.org/kotlin"
                                   image="kotlin"
                                   type="kotlin"
                                   g="{{group}}"


### PR DESCRIPTION
Kotlin DSL development started in https://github.com/gradle/kotlin-dsl, but we've since migrated all of the code and samples over to the main Gradle repository. This repository is now archived/inactive, so it may give the wrong impression for people who visit this link that Kotlin DSL is inactive/going away.

https://gradle.org/kotlin/ is a good landing page that links to all of our Kotlin DSL specific information.

(brief, plain english overview of your changes here)

This pull request makes the following changes:
* (your change here)
* (another change here)
* (etc)

(If there are changes to the UI, please include a screenshot so we
know what to look for!)

(If there are changes to user behavior in general, please make sure to
update the docs, as well)

It relates to the following issue #s:
* Fixes #X
