### PR TITLE
adds link to api guide url 

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -36,6 +36,17 @@
       <mat-icon>open_in_new</mat-icon>
     </a>
 
+    <span>|</span>
+
+    <a href="{{ smoAPIGuideUrl }}"
+       i18n-matTooltip matTooltip="API Guide"
+       target="_blank"
+       class="classic-search-link"
+       i18n>
+       API Guide
+      <mat-icon>open_in_new</mat-icon>
+    </a>
+
   </div>
 
   <div class="home-sub-text">

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -25,11 +25,13 @@ import { AppConfigService } from '../shared/config/app-config.service';
 export class HomeComponent implements OnInit {
 
   smoClassicLookUrl: string
+  smoAPIGuideUrl: string
 
   constructor(private appConfigService: AppConfigService) { }
 
   ngOnInit() {
     this.smoClassicLookUrl = this.appConfigService.getConfig().smoClassicLookUrl;
+    this.smoAPIGuideUrl = this.appConfigService.getConfig().smoAPIGuideUrl;
   }
 
 }

--- a/src/app/shared/config/app-config-mock.service.ts
+++ b/src/app/shared/config/app-config-mock.service.ts
@@ -20,26 +20,27 @@ import { Injectable } from "@angular/core";
 @Injectable()
 export class MockConfigService {
     private appConfig: Config;
-  
+
     constructor() {
       this.appConfig = {
-        repositoryBaseUrl: 'http://repo1.maven.org/maven2', 
+        repositoryBaseUrl: 'http://repo1.maven.org/maven2',
         production: "false",
         search: { endpoint: "" },
         stats: { endpoint: "" },
-        ossindex: {  
-          maven: { 
+        ossindex: {
+          maven: {
             endpoint: ""
           },
           resource: {
             endpoint: ""
-          }  
+          }
         },
         smoBaseUrl: "",
-        smoClassicLookUrl: ""
+        smoClassicLookUrl: "",
+        smoAPIGuideUrl: ""
       };
     }
-  
+
     getConfig() {
       return this.appConfig;
     }

--- a/src/app/shared/config/config.ts
+++ b/src/app/shared/config/config.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export interface Config {  
+export interface Config {
     production: string;
     search: Search;
     stats: Stats;
@@ -22,6 +22,7 @@ export interface Config {
     smoBaseUrl: string;
     repositoryBaseUrl: string;
     smoClassicLookUrl: string;
+    smoAPIGuideUrl: string;
 }
 
 interface Search {

--- a/src/assets/data/appConfig-prod.json
+++ b/src/assets/data/appConfig-prod.json
@@ -15,5 +15,7 @@
   },
   "smoBaseUrl": "https://search.maven.org/remotecontent?filepath=",
   "repositoryBaseUrl": "https://repo1.maven.org/maven2",
-  "smoClassicLookUrl": "https://search.maven.org/classic"
+  "smoClassicLookUrl": "https://search.maven.org/classic",
+  "smoAPIGuideUrl": "https://search.maven.org/classic/#api"
+
 }

--- a/src/assets/data/appConfig.json
+++ b/src/assets/data/appConfig.json
@@ -15,5 +15,6 @@
     },
     "smoBaseUrl": "http://localhost:8080/central/remotecontent?filepath=",
     "repositoryBaseUrl": "https://repo1.maven.org/maven2",
-    "smoClassicLookUrl": "https://search.maven.org/classic"
+    "smoClassicLookUrl": "https://search.maven.org/classic",
+    "smoAPIGuideUrl": "https://search.maven.org/classic/#api"
 }


### PR DESCRIPTION
(brief, plain english overview of your changes here)

This pull request makes the following changes:

changing json to point to api guide url
"smoAPIGuideUrl": "https://search.maven.org/classic/#api"



    <a href="{{ smoAPIGuideUrl }}"
       i18n-matTooltip matTooltip="API Guide"
       target="_blank"
       class="classic-search-link"
       i18n>
       API Guide
      <mat-icon>open_in_new</mat-icon>
    </a>

(If there are changes to the UI, please include a screenshot so we
know what to look for!)
Adds a link to API GUIDE url

(If there are changes to user behavior in general, please make sure to
update the docs, as well)

It relates to the following issue #s:

Fixes #X
Fixes #127